### PR TITLE
Fixes #62

### DIFF
--- a/lib/f5_image_prep/os-functions/openstack-wait-handler.sh
+++ b/lib/f5_image_prep/os-functions/openstack-wait-handler.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Copyright 2017 F5 Networks Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+source /config/os-functions/openstack-datasource.sh
+
+# OpenStack wait condition notification settings
+
+function wait_condition_notify() {
+
+    local wc_notify=$(get_user_data_value {bigip}{wait_condition_notify})
+
+    if [[ $(is_false ${wc_notify}) ]]; then
+	    log "Wait Condition will not be notified..."
+	else
+	    log "Notifying Wait Condition"
+        eval ${wc_notify}
+	fi
+}

--- a/lib/f5_image_prep/startup
+++ b/lib/f5_image_prep/startup
@@ -20,6 +20,7 @@ source /config/os-functions/openstack-license.sh
 source /config/os-functions/openstack-network.sh
 source /config/os-functions/openstack-ssh.sh
 source /config/os-functions/openstack-password.sh
+source /config/os-functions/openstack-wait-handler.sh
 
 function restore_issue() {
     cat /etc/issue | head -n 2 > /etc/issue
@@ -245,6 +246,8 @@ function main() {
     else
 		log "Cannot run OpenStack auto-configuration on non-VE platforms, quitting..."
     fi
+
+    wait_condition_notify
 
     cleanup_user_data
     tmsh modify sys global-settings gui-setup disabled | eval $LOGGER_CMD


### PR DESCRIPTION
This patch provides a script and associated JSON blob key that allows an administrator to
provide a wc_notify url to the startup script in much the same way that they would if they
were using cloud-init

os-functions/openstack-wait-handler.sh

In v13, using clout-init, this functionality is possible to add and allows an admin to
use Heat to accurately notify the admin when the bigip VM is complete. In versions <13
though, this is not possible. This patch adds functionality though so that it is possible
and therefore makes heat successfully return "complete" only when the VM is actually completely
configured and not earlier.