### PR TITLE
Feature.bigip 13 mgmt vs eth0 65

### DIFF
--- a/lib/f5_image_prep/os-functions/openstack-network.sh
+++ b/lib/f5_image_prep/os-functions/openstack-network.sh
@@ -50,7 +50,8 @@ function set_iface_value () {
     # initial chars in a BIGIP version string.  We do this
     # because the name of the managment interface changes
     # from eth0 to mgmt in version 13.
-    if (( "$1" >= "13"))
+    version=$(tmsh show /sys version | grep -i version)
+    if [ $(perl -le "print (\"\$$version\" =~ /(\d+)\.\d+\.\d+/)") -ge 13 ]
         then
             echo mgmt
         else

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-from setuptools import find_packages
 from setuptools import setup
 
 import f5_image_prep
@@ -32,4 +31,6 @@ setup(
         'Programming Language :: Python',
         'Intended Audience :: System Administrators',
     ],
+    install_requires=['python-keystoneclient == 1.7.2',
+                      'python-glanceclient == 1.2.0']
 )


### PR DESCRIPTION
    Changes to dynamically handle MGMT IFACE over ETH0 for >= 13

    Issues:
    Fixes #65

    Problem:
    * 13+ will have MGMT interface (as far as we know) over ETH0

    Analysis:
    * To handle this, a bit of perl was implemented to grab from tmsh output

    Tests

Reviewer/Assignee:
@zancas 