### PR TITLE
setup.py install does not require openstack clients

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #
 
-from setuptools import find_packages
 from setuptools import setup
 
 import f5_image_prep
@@ -32,4 +31,6 @@ setup(
         'Programming Language :: Python',
         'Intended Audience :: System Administrators',
     ],
+    install_requires=['python-keystoneclient == 1.7.2',
+                      'python-glanceclient == 1.2.0']
 )


### PR DESCRIPTION
Issues:
Fixes #60

Problem:
The setup.py installation of this repo does not require the proper
python client libraries for glance and keystone. This is currently done
in the f5-openstack-heat template with an apt-get install (which is not
correct). We'll move it to the setup.py here and then update the heat
template to remove that installation. The other big point is that we are
installation from latest with apt-get, so we're unsure of what we're
getting when we do the heat template install. With the setup.py change,
we'll fix it to a particular version that is tested and works.

Analysis:
Added install_requires to have the keystone and glance client for
openstack. These are pinned to specific versions. Those versions will
change between libert and mitaka etc.

Tests:
Tested with heat deployment from f5-openstack-heat repo.