### PR TITLE
mitaka and newton requires specific openstack client version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
         'Programming Language :: Python',
         'Intended Audience :: System Administrators',
     ],
-    install_requires=['python-keystoneclient == 1.7.2',
-                      'python-glanceclient == 1.2.0']
+    install_requires=['python-keystoneclient == 2.3.2',
+                      'python-glanceclient == 2.0.1']
 )


### PR DESCRIPTION
@szakeri 

Issues:
Fixes #68

Problem:
To ensure we can prep and upload an image in the mitaka and newton
releases of OpenStack, we need to bump the keystone and glance client
versions in the setup.py. The correct versions for those libraries in
mitaka are: 'python-keystoneclient == 2.3.2', 'python-glanceclient ==
2.0.1'. And for newton they are: 'python-keystoneclient == 3.5.1',
'python-glanceclient == 2.5.0'.

Analysis:
Bumped the version in mitaka for keystone and glance clients.

Tests:
Tested on mitaka stack when this change was first done.