### PR TITLE
Re-inserted a rm statement for firstboot file

### DIFF
--- a/lib/f5_image_prep/startup
+++ b/lib/f5_image_prep/startup
@@ -247,6 +247,11 @@ function main() {
 		log "Cannot run OpenStack auto-configuration on non-VE platforms, quitting..."
     fi
 
+    # Delete the /config/firstboot file, we have completed initial setup
+    if [[ ${IS_FIRST_BOOT} == "true" ]]; then
+        rm -f $FIRST_BOOT_FILE
+    fi
+
     wait_condition_notify
 
     cleanup_user_data


### PR DESCRIPTION
Issues:
Fixes #75 

Problem:
* The firstboot is given to the BIG-IP from onboarding
* After the initial, firstboot init cycle, this file should be removed
  * Without it's removal config collisions could occur
  * Without it's removal reboot cycles take longer

Analysis:
* This inserts the removal statement after all first boot inits

Tests:
None.  This is a startup scripting for onboarding.  While we have some
tests in regards to this, it would be very difficult to tell whether or
not the first boot init was done twice after a reboot.

Assignee:
@richbrowne 

Reviewers:
@pjbreaux 

What this change addresses:
=====================
This change will delete the `/config/firstboot` file introduced by the onboarding scripting.  This will prevent subsequent boot sessions from performing the initial boot cycle, which costs time and resource preventing the BIG-IP from booting as quickly.

Where should the reviewer start:
========================
This is a simple change and only adds 1 if/then statement.  This should be the focus.