### PR TITLE
Change link to docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,7 @@ Introduction
 
 The standard F5 BIG-IP Virtual Edition (VE) images available from f5.com must be 'patched' in order to be compatible with OpenStack. This repository's contents make it possible to patch and upload F5 VE images into OpenStack Glance.
 
-The easiest way to patch a VE image for use in OpenStack is to use the F5 Heat template 'patch_upload_ve_image.yaml'. Please see the `F5 Heat User Guide <http://f5-openstack-heat.readthedocs.io/en/latest/map_heat-user-guide.html>`_ for instructions.
+The easiest way to patch a VE image for use in OpenStack is to use the F5 Heat template 'patch_upload_ve_image.yaml'. Please see the `F5 Heat User Guide <http://clouddocs.f5.com/cloud/openstack/v1/heat/index.html>`_ for instructions.
 
 For Developers
 --------------


### PR DESCRIPTION
Update the link to external docs from the deprecated Read the Docs site to CloudDocs